### PR TITLE
chore: Migrate to Hygraph's New Asset syntax

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Next.js: debug server-side",
       "type": "node-terminal",
       "request": "launch",
-      "command": "yarn dev"
+      "command": "pnpm run dev"
     },
     {
       "name": "Next.js: debug client-side",
@@ -17,7 +17,7 @@
       "name": "Next.js: debug full stack",
       "type": "node-terminal",
       "request": "launch",
-      "command": "yarn dev",
+      "command": "pnpm run dev",
       "serverReadyAction": {
         "pattern": "started server on .+, url: (https?://.+)",
         "uriFormat": "%s",

--- a/next.config.js
+++ b/next.config.js
@@ -11,8 +11,15 @@ const nextConfig = {
   outputFileTracing: true,
   env: {
     NEXT_PUBLIC_URL: process.env.NEXT_PUBLIC_URL,
+    NEXT_CMS_ASSET_ENV_ID: process.env.NEXT_CMS_ASSET_ENV_ID,
   },
   images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.graphassets.com',
+      },
+    ],
     domains: ['media.graphassets.com'],
     formats: ['image/webp'],
   },

--- a/src/app/_components/hygraph-image-with-loader.tsx
+++ b/src/app/_components/hygraph-image-with-loader.tsx
@@ -3,9 +3,9 @@
 import Image, { ImageLoaderProps, ImageProps } from 'next/image';
 
 export const loader = ({ src, width }: ImageLoaderProps) => {
-  const CDN_URL = 'https://media.graphassets.com/';
+  const CDN_URL = `https://us-east-1.graphassets.com/${process.env.NEXT_CMS_ASSET_ENV_ID}/`;
   const srcInfo = src.split(CDN_URL)[1];
-  const transform = `resize=width:${width}/output=format:webp/quality=value:90/`;
+  const transform = `resize=width:${width}/output=format:webp/`;
   return `${CDN_URL}${transform}${srcInfo}`;
 };
 


### PR DESCRIPTION
-  Add remotePatterns for GraphAssets in next.config.js
-  Update HygraphImageWithLoader to use environment variable for asset environment ID